### PR TITLE
Added enterFullScreen and exitFullScreen methods to Window

### DIFF
--- a/Sources/Window.swift
+++ b/Sources/Window.swift
@@ -69,4 +69,12 @@ public class Window: Bin {
         get { return _titleBar }
         set { gtk_window_set_titlebar(castedPointer(), newValue?.widgetPointer) }
     }
+
+    public func enterFullScreen() {
+        gtk_window_fullscreen(castedPointer())
+    }
+
+    public func exitFullScreen() {
+        gtk_window_unfullscreen(castedPointer())
+    }
 }

--- a/SwiftGtkDemo/Sources/main.swift
+++ b/SwiftGtkDemo/Sources/main.swift
@@ -64,7 +64,21 @@ app.run { window in
     }
 
     buttonBox.add(imageButton)
+    
+    let fullScreenButton = Button(label: "Enter Full Screen")
+    fullScreenButton.clicked = { _ in
+        window.enterFullScreen()
+    }
+    
+    buttonBox.add(fullScreenButton)
 
+    let exitFullScreenButton = Button(label: "Exit Full Screen")
+    exitFullScreenButton.clicked = { _ in
+        window.exitFullScreen()
+    }
+    
+    buttonBox.add(exitFullScreenButton)
+    
     let textView = TextView()
     textView.backspace = { _ in
         print("backspace")


### PR DESCRIPTION
This adds two new methods to `Window`: `enterFullScreen()` and `exitFullScreen()`. I tested them on macOS and on my Raspberry Pi and they worked on both. I updated the sample project with two new buttons to demonstrate the new feature.