### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version: 5.6
 import PackageDescription
 
 #if os(OSX)


### PR DESCRIPTION
make some change to fix this problem:
error: the manifest is missing a Swift tools version specification; consider prepending to the manifest '// swift-tools-version: 5.6' to specify the current Swift toolchain version as the lowest Swift version supported by the project; if such a specification already exists, consider moving it to the top of the manifest, or prepending it with '//' to help Swift Package Manager find it
